### PR TITLE
Add memo and memoCustomCompareProps

### DIFF
--- a/lib/react.mli
+++ b/lib/react.mli
@@ -368,15 +368,14 @@ module Fragment : sig
       let make = to_component makeInternal]
 end
 
-(*
- [@bs.module "react"]
- external memo: component('props) => component('props) = "";
+val memo : 'props component -> 'props component
+  [@@js.global "__LIB__react.memo"]
 
- [@bs.module "react"]
- external memoCustomCompareProps:
-   (component('props), [@bs.uncurry] (('props, 'props) => bool)) =>
-   component('props) =
-   "memo";
+val memoCustomCompareProps :
+  'props component -> ('props -> 'props -> bool) -> 'props component
+  [@@js.global "__LIB__react.memo"]
+
+(*
 
  module Suspense = {
    [@bs.obj]

--- a/ppx/test/input.re
+++ b/ppx/test/input.re
@@ -66,6 +66,25 @@ module ForwardRef = {
     );
 };
 
+module Memo = {
+  [@react.component]
+  let make =
+    React.memo((~a) => {
+      <div> {Printf.sprintf("`a` is %s", a) |> React.string} </div>
+    });
+};
+
+module MemoCustomCompareProps = {
+  [@react.component]
+  let make =
+    React.memoCustomCompareProps(
+      (~a) => {
+        <div> {Printf.sprintf("`a` is %d", a) |> React.string} </div>
+      },
+      (prevPros, nextProps) => false,
+    );
+};
+
 let fragment = foo => [@bla] <> foo </>;
 
 let polyChildrenFragment = (foo, bar) => <> foo bar </>;

--- a/ppx/test/pp.expected
+++ b/ppx/test/pp.expected
@@ -416,6 +416,97 @@ module ForwardRef =
            make theRef in
          Test$ForwardRef)
   end
+module Memo =
+  struct
+    let makeProps
+      : a:'a ->
+          ?key:string ->
+            unit ->
+              < a: 'a Js_of_ocaml.Js.readonly_prop   >  Js_of_ocaml.Js.t
+      =
+      fun ~a ->
+        fun ?key ->
+          fun _ ->
+            let open Js_of_ocaml.Js.Unsafe in
+              obj
+                ((([|(Option.map
+                        (fun _ ->
+                           ("key",
+                             (inject
+                                ((Option.map Js_of_ocaml.Js.string key) |>
+                                   Js_of_ocaml.Js.Opt.option)))) key);(
+                     Some ("a", (inject a)))|] |> Array.to_list)
+                    |> (List.filter_map (fun x -> x)))
+                   |> Array.of_list)
+    let make =
+      ((fun ~a ->
+          ReactDOM.createDOMElementVariadic "div"
+            ~props:(ReactDOM.domProps ())
+            [(Printf.sprintf "`a` is %s" a) |> React.string])
+      [@warning "-16"])
+    let make =
+      React.memo
+        (let Test$Memo
+           (Props :
+             < a: 'a Js_of_ocaml.Js.readonly_prop   >  Js_of_ocaml.Js.t)
+           =
+           make
+             ~a:((fun (type res) ->
+                    fun (type a0) ->
+                      fun (a0 : a0 Js_of_ocaml.Js.t) ->
+                        fun
+                          (_ :
+                            a0 -> < get: res   ;.. >  Js_of_ocaml.Js.gen_prop)
+                          -> (Js_of_ocaml.Js.Unsafe.get a0 "a" : res))
+                   (Props : < .. >  Js_of_ocaml.Js.t) (fun x -> x#a)) in
+         Test$Memo)
+  end
+module MemoCustomCompareProps =
+  struct
+    let makeProps
+      : a:'a ->
+          ?key:string ->
+            unit ->
+              < a: 'a Js_of_ocaml.Js.readonly_prop   >  Js_of_ocaml.Js.t
+      =
+      fun ~a ->
+        fun ?key ->
+          fun _ ->
+            let open Js_of_ocaml.Js.Unsafe in
+              obj
+                ((([|(Option.map
+                        (fun _ ->
+                           ("key",
+                             (inject
+                                ((Option.map Js_of_ocaml.Js.string key) |>
+                                   Js_of_ocaml.Js.Opt.option)))) key);(
+                     Some ("a", (inject a)))|] |> Array.to_list)
+                    |> (List.filter_map (fun x -> x)))
+                   |> Array.of_list)
+    let make =
+      ((fun ~a ->
+          ReactDOM.createDOMElementVariadic "div"
+            ~props:(ReactDOM.domProps ())
+            [(Printf.sprintf "`a` is %d" a) |> React.string])
+      [@warning "-16"])
+    let make =
+      React.memoCustomCompareProps
+        (let Test$MemoCustomCompareProps
+           (Props :
+             < a: 'a Js_of_ocaml.Js.readonly_prop   >  Js_of_ocaml.Js.t)
+           =
+           make
+             ~a:((fun (type res) ->
+                    fun (type a0) ->
+                      fun (a0 : a0 Js_of_ocaml.Js.t) ->
+                        fun
+                          (_ :
+                            a0 -> < get: res   ;.. >  Js_of_ocaml.Js.gen_prop)
+                          -> (Js_of_ocaml.Js.Unsafe.get a0 "a" : res))
+                   (Props : < .. >  Js_of_ocaml.Js.t) (fun x -> x#a)) in
+         Test$MemoCustomCompareProps)
+        (fun prevPros -> fun nextProps -> false)
+  end
 let fragment foo =
   ((React.createElement React.Fragment.make
       ((React.Fragment.makeProps ~children:foo ())[@bla ]))


### PR DESCRIPTION
Adds support for [`React.memo`](https://reactjs.org/docs/react-api.html#reactmemo).

Includes a small diff on the ppx to be able to support wrapped render functions with a second argument (for `memoCustomCompareProps` `compareProps` function). This patch could be back ported to ReasonReact ppx easily.